### PR TITLE
Allow binary JSON dumps

### DIFF
--- a/psycopg/psycopg/types/json.py
+++ b/psycopg/psycopg/types/json.py
@@ -14,7 +14,7 @@ from ..pq import Format
 from ..adapt import Buffer, Dumper, Loader, PyFormat, AdaptersMap
 from ..errors import DataError
 
-JsonDumpsFunction = Callable[[Any], str]
+JsonDumpsFunction = Callable[[Any], [Union[str, bytes]]]
 JsonLoadsFunction = Callable[[Union[str, bytes]], Any]
 
 
@@ -132,7 +132,10 @@ class _JsonDumper(Dumper):
             obj = obj.obj
         else:
             dumps = self.dumps
-        return dumps(obj).encode()
+        data = dumps(obj)
+        if isinstance(data, str):
+            data = data.encode()
+        return data
 
 
 class JsonDumper(_JsonDumper):


### PR DESCRIPTION
Some JSON libraries, in particular the widespread [orjson](https://github.com/ijl/orjson#quickstart) library, directly dump data in binary format.

This change allows it and avoids having to decode/encode in these cases by testing the return type of the `dumps` function.